### PR TITLE
RANDOM_REG32 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.cproject
+/.project

--- a/ESP8266TrueRandom.h
+++ b/ESP8266TrueRandom.h
@@ -1,7 +1,9 @@
-/**
+/*
  * TrueRandom - A true random number generator for Arduino.
- *
+ * This is variant of original work originally implemented as:
+ * https://code.google.com/archive/p/tinkerit/ https://github.com/Cathedrow/TrueRandom
  * Copyright (c) 2010 Peter Knight, Tinker.it! All rights reserved.
+ * Now modified for the ESP8266
  */
 
 #ifndef ESP8266TrueRandom_h
@@ -9,22 +11,26 @@
 
 #include <Arduino.h>
 #include <inttypes.h>
+
 class ESP8266TrueRandomClass
 {
   public:
-    int rand();
-    long random();
-    long random(long howBig);
-    long random(long howsmall, long how);
-    int randomBit(void);
-    char randomByte(void);
-    void memfill(char* location, int size);
-    void mac(uint8_t* macLocation);
-    void uuid(uint8_t* uuidLocation);
-    String uuidToString(uint8_t* uuidLocation);
+	ICACHE_FLASH_ATTR ESP8266TrueRandomClass();
+	ICACHE_FLASH_ATTR int rand();
+	ICACHE_FLASH_ATTR long random();
+	ICACHE_FLASH_ATTR long random(long howBig);
+	ICACHE_FLASH_ATTR long random(long howsmall, long how);
+	ICACHE_FLASH_ATTR int randomBit(void);
+	ICACHE_FLASH_ATTR char randomByte(void);
+	ICACHE_FLASH_ATTR void memfill(char* location, int size);
+	ICACHE_FLASH_ATTR void mac(uint8_t* macLocation);
+	ICACHE_FLASH_ATTR void uuid(uint8_t* uuidLocation);
+	ICACHE_FLASH_ATTR String uuidToString(uint8_t* uuidLocation);
+    bool useRNG;
   private:
-    int randomBitRaw(void);
-    int randomBitRaw2(void);
+    unsigned long lastYield;
+    ICACHE_FLASH_ATTR int randomBitRaw(void);
+    ICACHE_FLASH_ATTR int randomBitRaw2(void);
 };
 extern ESP8266TrueRandomClass ESP8266TrueRandom;
 #endif

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ESP8266TrueRandom
 TrueRandom Arduino library for the ESP8266
 
-**The code is only slightly modified from tinkerit TrueRandom to work on the ESP8266, and this is probably not as random as the original. However, it still performs better than the original random function, based on my tests. What I wanted was a library to generate an UUID for an home automation system using ESP8266, and unless you have millions of devices, I think this is random enough to avoid conflicts.**
+**The code is only slightly modified from [tinkerit TrueRandom](https://code.google.com/archive/p/tinkerit/) to work on the ESP8266, and this is probably not as random as the original. However, it still performs better than the original random function, based on my tests. What I wanted was a library to generate an UUID for an home automation system using ESP8266, and unless you have millions of devices, I think this is random enough to avoid conflicts.**
 
 ## Introduction
 
@@ -9,7 +9,7 @@ ESP8266TrueRandom generates true random numbers on ESP8266. They are different e
 
 ## Compatibility
 
-ESP8266TrueRandom currently functions on the ESP8266. ESP8266TrueRandom uses TOUT pin. Do not connect anything to this pin. These restrictions may be removed in future versions of this library.
+ESP8266TrueRandom currently functions on the ESP8266. ESP8266TrueRandom reads the ESP8266 internal hardware random number generator register by default or alternatively can use the A0/TOUT pin when useRNG is set to false. If using A0/TOUT do not connect anything to this pin and leave it floating.
 
 ## Download
 
@@ -95,6 +95,6 @@ Returns a String containing the string representation of the given UUID
 
 ## How TrueRandom works
 
-It is hard to get a truly random number from Arduino. ESP8266TrueRandom does it by measuring TOUT pin, and then discarding all but the least significant bit of the measured value. However, that isn't noisy enough, so a [von Neumann whitening algorithm](http://en.wikipedia.org/wiki/Hardware_random_number_generator) gathers enough entropy from multiple readings to ensure a fair distribution of 1s and 0s.
+ESP8266TrueRandom achieves random numbers by reading the ESP8266 internal hardware random number generator register or by by measuring the A0/TOUT pin. However, that isn't noisy enough so a [von Neumann whitening algorithm](http://en.wikipedia.org/wiki/Hardware_random_number_generator) gathers enough entropy from multiple readings to ensure a fair distribution of 1s and 0s.
 
 The other functions within ESP8266TrueRandom construct the requested values by gathering just enough random bits to produce the required numbers. Generating a random bit takes time, so a significant part of the code works to ensure the random bits are used as efficiently as possible.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ESP8266TrueRandom
 TrueRandom Arduino library for the ESP8266
 
-**The code is only slightly modified from [tinkerit TrueRandom](https://code.google.com/archive/p/tinkerit/) to work on the ESP8266, and this is probably not as random as the original. However, it still performs better than the original random function, based on my tests. What I wanted was a library to generate an UUID for an home automation system using ESP8266, and unless you have millions of devices, I think this is random enough to avoid conflicts.**
+**The code is only slightly modified from [tinkerit TrueRandom](https://code.google.com/archive/p/tinkerit/wikis/TrueRandom.wiki) to work on the ESP8266, and this is probably not as random as the original. However, it still performs better than the original random function, based on my tests. What I wanted was a library to generate an UUID for an home automation system using ESP8266, and unless you have millions of devices, I think this is random enough to avoid conflicts.**
 
 ## Introduction
 

--- a/examples/Benchmark/Benchmark.ino
+++ b/examples/Benchmark/Benchmark.ino
@@ -1,0 +1,48 @@
+#include "ESP8266TrueRandom.h"
+
+unsigned long startTime;
+int i;
+
+void setup() {
+  Serial.begin(9600);
+  
+  Serial.println("ESP8266TrueRandom benchmark");
+  Serial.println("--------------------");
+  Serial.println();
+
+  Serial.print("Arduino clock speed: ");
+  Serial.print(F_CPU/1000000);
+  Serial.println("MHz");
+
+  Serial.print("randomBit(): ");
+  startTime = millis();
+  ESP8266TrueRandom.randomBit();
+  Serial.print(millis() - startTime);
+  Serial.println("ms");
+  
+  Serial.print("randomByte(): ");
+  startTime = millis();
+  ESP8266TrueRandom.randomByte();
+  Serial.print(millis() - startTime);
+  Serial.println("ms");
+  
+  Serial.print("random(100): ");
+  startTime = millis();
+  ESP8266TrueRandom.random(100);
+  Serial.print(millis() - startTime);
+  Serial.println("ms");
+  
+  Serial.print("random(65536): ");
+  startTime = millis();
+  ESP8266TrueRandom.random(65536);
+  Serial.print(millis() - startTime);
+  Serial.println("ms");
+  
+  Serial.print("random(65537): ");
+  startTime = millis();
+  ESP8266TrueRandom.random(65537);
+  Serial.print(millis() - startTime);
+  Serial.println("ms");
+}
+void loop() {
+}

--- a/examples/Die/Die.ino
+++ b/examples/Die/Die.ino
@@ -1,0 +1,33 @@
+/*
+ * A simple electronic die.
+ *
+ * Press the reset button to throw a set of dice.
+ *
+ */
+
+#include "ESP8266TrueRandom.h"
+
+void setup() {
+  Serial.begin(9600);
+  Serial.println("Throwing...");
+  delay(1000);
+  
+  Serial.print("6 sided die: ");
+  Serial.println(ESP8266TrueRandom.random(1,7));
+  Serial.print("4 sided die: ");
+  Serial.println(ESP8266TrueRandom.random(1,5));
+  Serial.print("8 sided die: ");
+  Serial.println(ESP8266TrueRandom.random(1,9));
+  Serial.print("10 sided die: ");
+  Serial.println(ESP8266TrueRandom.random(1,11));
+  Serial.print("12 sided die: ");
+  Serial.println(ESP8266TrueRandom.random(1,13));
+  Serial.print("20 sided die: ");
+  Serial.println(ESP8266TrueRandom.random(1,21));
+  Serial.print("100 sided die: ");
+  Serial.println(ESP8266TrueRandom.random(1,101));
+}
+
+void loop() {
+  ; // Do nothing
+}

--- a/examples/Magic8Ball/Magic8Ball.ino
+++ b/examples/Magic8Ball/Magic8Ball.ino
@@ -1,0 +1,59 @@
+/*
+ * A magic 8 ball.
+ *
+ * Press the reset button to see into the future.
+ *
+ * View the answer to your question in the Serial Monitor, at 19200 baud.
+ *
+ * Press the Arduino reset button to ask another question.
+ *
+ */
+
+#include "ESP8266TrueRandom.h"
+
+char* answers[20] = {
+  "As I see it, yes",
+  "It is certain",
+  "It is decidedly so",
+  "Mostly likely",
+  "Outlook good",
+  "Signs point to yes",
+  "Without a doubt",
+  "Yes",
+  "Yes - definitely",
+  "You may rely on it",
+  "Reply hazy, try again",
+  "Ask again later",
+  "Better not tell you now",
+  "Cannot predict now",
+  "Concentrate and ask again",
+  "Don't count on it",
+  "My reply is no",
+  "My sources say no",
+  "Outlook not so good",
+  "Very doubtful"
+};
+
+int answerNumber;
+
+void setup() {
+  Serial.begin(9600);
+
+  Serial.print("The answer is ");
+  
+  // Dramatic pause
+  delay(1000);
+  Serial.print(". ");
+  delay(1000);
+  Serial.print(". ");
+  delay(1000);
+  Serial.print(". ");
+  delay(1000);
+
+  answerNumber = ESP8266TrueRandom.random(20);
+  Serial.println( answers[answerNumber] );
+}
+
+void loop() {
+  ; // Do nothing
+}

--- a/examples/SetRandomSeed/SetRandomSeed.ino
+++ b/examples/SetRandomSeed/SetRandomSeed.ino
@@ -1,0 +1,28 @@
+/*
+ * SetRandomSeed.
+ *
+ * You can use ESP8266TrueRandom to set the seed for the normal Arduino
+ * random number generator.
+ *
+ * That way you can quickly generate random numbers that are
+ * different every time using the random number generator.
+ */
+
+#include "ESP8266TrueRandom.h"
+
+int i;
+
+void setup() {
+  Serial.begin(9600);
+  Serial.println("Here are some pseudo random digits.");
+  for (i=1;i<=20;i++) Serial.print(random(10));
+  Serial.println();
+
+  randomSeed(ESP8266TrueRandom.random());
+  
+  Serial.println("Here are some random seeded pseudo random digits.");
+  for (i=1;i<=20;i++) Serial.print(random(10));
+  Serial.println();
+}
+void loop() {
+}

--- a/examples/Uuid/Uuid.ino
+++ b/examples/Uuid/Uuid.ino
@@ -1,0 +1,37 @@
+/*
+ * Uuid
+ *
+ * UUIDs are unique numbers that are used for identifying individual units,
+ * functions, programmes, or whatever you want to tag.
+ *
+ * In this demo, press the Arduino Reset button to generate a new number.
+ *
+ * UUIDs can be assigned sequentially from allocated blocks of numbers, but
+ * they are most powerful when randomly assigned. UUIDs are such big numbers
+ * that, for all effective purposes, no two numbers will ever match.
+ *
+ * UUIDs are particularly useful in web-aware devices, or radio networks.
+ *
+ * For a discussion of the use of UUIDs, see
+ *   http://en.wikipedia.org/wiki/Universally_Unique_Identifier
+ *
+ * For implementation details of UUIDs, see
+ *   http://tools.ietf.org/html/rfc4122
+ */
+
+#include "ESP8266TrueRandom.h"
+
+byte uuidNumber[16]; // UUIDs in binary form are 16 bytes long
+
+void setup() {
+  Serial.begin(9600);
+
+  // Generate a new UUID
+  ESP8266TrueRandom.uuid(uuidNumber);
+  String uuidStr = ESP8266TrueRandom.uuidToString(uuidNumber);
+  Serial.println("The UUID number is " + uuidStr);
+  
+}
+
+void loop() {
+}


### PR DESCRIPTION
This pull request introduces the use of the RANDOM_REG32 hardware RNG register on the ESP8266. This frees up use of the A0/TOUT pin and RANDOM_REG32 is now used by default but if necessary, the legacy behavior of using A0/TOUT is still supported by setting useRNG==false.
