### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,20 +6,20 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ESP8266TrueRandom  KEYWORD1
+ESP8266TrueRandom	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-rand  KEYWORD2
-random  KEYWORD2
-randomBit KEYWORD2
-randomByte  KEYWORD2
-memfill KEYWORD2
-mac KEYWORD2
-uuid  KEYWORD2
-uuidToString  KEYWORD2
+rand	KEYWORD2
+random	KEYWORD2
+randomBit	KEYWORD2
+randomByte	KEYWORD2
+memfill	KEYWORD2
+mac	KEYWORD2
+uuid	KEYWORD2
+uuidToString	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords